### PR TITLE
Improve Results.py

### DIFF
--- a/pygridsim/core.py
+++ b/pygridsim/core.py
@@ -179,7 +179,9 @@ class PyGridSim:
 
         Args:
             queries (list[str]):
-                A list of queries to the circuit ("Voltages", "Losses", "TotalPower")
+                A list of queries to the circuit: one of ("Voltages", "Losses", "TotalPower")
+                or partial queries ("RealLoss", "ReactiveLoss", "RealPower", "ReactivePower")
+                that query one component of Losses/TotalPower
             export_path (str, optional):
                 The file path to export results. If empty, results are not exported.
                 Defaults to "".

--- a/pygridsim/results.py
+++ b/pygridsim/results.py
@@ -8,20 +8,25 @@ from altdss import altdss
 
 
 def _query_solution(query):
-    match query:
-        case "Voltages":
+    query_fix = query.lower().replace(" ", "")
+    match query_fix:
+        case "voltages":
             bus_vmags = {}
             for bus_name, bus_vmag in zip(altdss.BusNames(), altdss.BusVMag()):
                 bus_vmags[bus_name] = float(bus_vmag)
             return bus_vmags
-        case "Losses":
+        case "losses":
             vector_losses = altdss.Losses()
             losses = {}
             losses["Active Power Loss"] = vector_losses.real
             losses["Reactive Power Loss"] = vector_losses.imag
             return losses
-        case "TotalPower":
-            return altdss.TotalPower()
+        case "totalpower":
+            vector_power = altdss.TotalPower()
+            power = {}
+            power["Active Power"] = vector_power.real
+            power["Reactive Power"] = vector_power.imag
+            return power
         case _:
             return "Invalid"
 

--- a/pygridsim/results.py
+++ b/pygridsim/results.py
@@ -9,6 +9,8 @@ from altdss import altdss
 
 def _query_solution(query):
     query_fix = query.lower().replace(" ", "")
+    vector_losses = altdss.Losses()
+    vector_power = altdss.TotalPower()
     match query_fix:
         case "voltages":
             bus_vmags = {}
@@ -16,17 +18,23 @@ def _query_solution(query):
                 bus_vmags[bus_name] = float(bus_vmag)
             return bus_vmags
         case "losses":
-            vector_losses = altdss.Losses()
             losses = {}
             losses["Active Power Loss"] = vector_losses.real
             losses["Reactive Power Loss"] = vector_losses.imag
             return losses
         case "totalpower":
-            vector_power = altdss.TotalPower()
             power = {}
             power["Active Power"] = vector_power.real
             power["Reactive Power"] = vector_power.imag
             return power
+        case "activeloss" | "activepowerloss" | "realloss" | "realpowerloss":
+            return vector_losses.real
+        case "reactiveloss" | "reactivepowerloss":
+            return vector_losses.imag
+        case "activepower" | "realpower":
+            return vector_power.real
+        case "reactivepower":
+            return vector_power.imag
         case _:
             return "Invalid"
 

--- a/pygridsim/results.py
+++ b/pygridsim/results.py
@@ -22,7 +22,7 @@ def _query_solution(query):
             losses["Active Power Loss"] = vector_losses.real
             losses["Reactive Power Loss"] = vector_losses.imag
             return losses
-        case "totalpower":
+        case "totalpower" | "power":
             power = {}
             power["Active Power"] = vector_power.real
             power["Reactive Power"] = vector_power.imag

--- a/pygridsim/results.py
+++ b/pygridsim/results.py
@@ -17,7 +17,7 @@ def _query_solution(query):
             for bus_name, bus_vmag in zip(altdss.BusNames(), altdss.BusVMag()):
                 bus_vmags[bus_name] = float(bus_vmag)
             return bus_vmags
-        case "losses":
+        case "losses" | "loss":
             losses = {}
             losses["Active Power Loss"] = vector_losses.real
             losses["Reactive Power Loss"] = vector_losses.imag

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -170,7 +170,9 @@ class TestDefaultRangeCircuit(unittest.TestCase):
         circuit.add_lines([("source", "load0"), ("generator0", "load0")])
         circuit.solve()
         # Should be flexible with capitalization, spaces
-        queries = ["Voltages", "losses", "Total Power", "realpowerloss", "Active Power"]
+        queries = ["Voltages", "losses", "Total Power"]
+        # Add "partial" queries to just parts of losses/total power
+        queries += ["realpowerloss", "reactive Loss", "Active Power", "reactivepower"]
         print(circuit.results(queries))
 
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -162,6 +162,16 @@ class TestDefaultRangeCircuit(unittest.TestCase):
         with self.assertRaises(Exception):
             circuit.update_source(source_type=SourceType.TURBINE)
 
+    def test_012_all_results(self):
+        circuit = PyGridSim()
+        circuit.update_source()
+        circuit.add_load_nodes()
+        circuit.add_generators(num=2, gen_type="small")
+        circuit.add_lines([("source", "load0"), ("generator0", "load0")])
+        circuit.solve()
+        # Should be flexible with capitalization, spaces
+        print(circuit.results(["Voltages", "losses", "Total Power"]))
+
 
 class TestCustomizedCircuit(unittest.TestCase):
     """

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -170,7 +170,7 @@ class TestDefaultRangeCircuit(unittest.TestCase):
         circuit.add_lines([("source", "load0"), ("generator0", "load0")])
         circuit.solve()
         # Should be flexible with capitalization, spaces
-        print(circuit.results(["Voltages", "losses", "Total Power"]))
+        print(circuit.results(["Voltages", "losses", "Total Power", "realpowerloss", "Active Power"]))
 
 
 class TestCustomizedCircuit(unittest.TestCase):

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -170,7 +170,8 @@ class TestDefaultRangeCircuit(unittest.TestCase):
         circuit.add_lines([("source", "load0"), ("generator0", "load0")])
         circuit.solve()
         # Should be flexible with capitalization, spaces
-        print(circuit.results(["Voltages", "losses", "Total Power", "realpowerloss", "Active Power"]))
+        queries = ["Voltages", "losses", "Total Power", "realpowerloss", "Active Power"]
+        print(circuit.results(queries))
 
 
 class TestCustomizedCircuit(unittest.TestCase):


### PR DESCRIPTION
Previously: the results allowed for voltages (list of voltages), losses (dictionary of active power loss, reactive power loss) and totalpower (just kept active power, reactive power in an unreadable vector).

In this PR:
- fixed totalpower to more clearly print out what is active power vs reactive power
- no longer case-sensitive or space-sensitive
- Users can also query the parts of losses or totalpower separately if they choose to.
- i.e. if they just care about real power and losses they can have their query be ["RealPower", "RealLoss"], instead of having to query losses and totalpower and manually parse the results for the "real" parts